### PR TITLE
Fixed linking of libmath on non-MSVC targets in src/CMakeLists.txt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,4 +26,8 @@ set(HDRS prtyp.h
          tmpstore.h
          types.h)
 
- add_executable(view3d ${HDRS} ${SRCS})
+add_executable(view3d ${HDRS} ${SRCS})
+
+if(NOT MSVC)
+    target_link_libraries(view3d m)
+endif()


### PR DESCRIPTION
I tried to build this project for a colleague on a Debian Linux machine, and while the Makefile worked perfectly fine, the `CMakeLists.txt` was missing the explicit link target `libmath`, so I just added that for non-MSVC targets.